### PR TITLE
print in stdout when result is char and always with option -p

### DIFF
--- a/olambda
+++ b/olambda
@@ -3,6 +3,18 @@
 arg_list = argv();
 n = nargin;
 
+% parse '-p' to print the output in the terminal instead of writing to file
+print = false;
+for i=1:n
+    if strcmp(arg_list{i}, '-p')
+        print = true;
+        for j=i:n-1, arg_list{j} = arg_list{j+1}; end
+        arg_list{n} = [];
+        n = n - 1;
+        break;
+    end
+end
+
 % parse '-o' for the output filename
 output = '-';
 for i=1:n
@@ -47,8 +59,8 @@ func = str2func(prog);
 r = func(imgs{:});
 
 % print or save the result
-if numel(r) == 1
-    fprintf("%f\n", r);
+if print || ischar(r) || numel(r) == 1
+    disp(r);
 else
     iio_write(output, r);
 end


### PR DESCRIPTION
In addition to the case `numel(r) == 1`, print the result in stdout in the two following cases:
- the result is a string
- the option `-p` is provided

Handy when you just want info on the images (e.g. `size(x)`) or want to know the values at a particular position in the matrix (e.g. `x(100:105, :, 1)`). I changed `fprintf` by `disp` for this last case, because matrix are better displayed with `disp`.