### PR TITLE
[feature] load and save vectors/matrices in textfiles (.txt or .mat)

### DIFF
--- a/olambda
+++ b/olambda
@@ -90,11 +90,10 @@ preprog = '';
 for i=1:argc
     preprog = [preprog imgs_names(i) '=imgs{' int2str(i) '};'];
 end
-prog = regexprep(prog, '(\s|;)*$', ';');
-prog = [preprog prog];
+prog = regexprep([prog ';'], '(\s|;)*$', ';');
 
 % run the code on the image
-eval(prog);
+eval([preprog prog]);
 
 % ans is not defined in two cases:
 % 1. All results are assigned to a variable --> assign last assigned one to res
@@ -138,7 +137,7 @@ else
         otherwise
             iio_write(output, res);
     end
-    if verbose && exist('output', 'var')
+    if verbose
         fprintf(2, ['result saved to: ' output '\n']);
     end
 end

--- a/olambda
+++ b/olambda
@@ -68,11 +68,17 @@ prog = arg_list{argc};
 arg_list(argc, :) = [];
 argc = argc - 1;
 
-% read the images
+% read the images or matrices stored in text files
 imgs = {};
 imgs_names = ['x':'z', 'a':'w']; % we do not handle more than 26 input images
 for i=1:argc
-    imgs{i} = iio_read(arg_list{i});
+    [fpath, fname, fext] = fileparts(arg_list{i});
+    switch fext
+        case {'.txt', '.mat'}
+            imgs{i} = load(arg_list{i});
+        otherwise
+            imgs{i} = iio_read(arg_list{i});
+    end
     if verbose
         fprintf(2, ['%c=''%s'' (%d' ...
                     repmat('x%d', [1, length(size(imgs{i}))-1]) ')\n'], ...
@@ -84,7 +90,8 @@ preprog = '';
 for i=1:argc
     preprog = [preprog imgs_names(i) '=imgs{' int2str(i) '};'];
 end
-prog = [preprog prog ';']; % two semicolons are ok
+prog = regexprep(prog, '(\s|;)*$', ';');
+prog = [preprog prog];
 
 % run the code on the image
 eval(prog);
@@ -121,10 +128,19 @@ if verbose
 end
 
 % print or save the result
-if print || ischar(res) || numel(res) == 1
+if strcmp(output,'-') && (print || ischar(res) || numel(res) == 1)
     disp(res);
 else
-    iio_write(output, res);
+    [fpath, fname, fext] = fileparts(output);
+    switch fext
+        case {'.txt', '.mat'}
+            save('-ascii', output, 'res');
+        otherwise
+            iio_write(output, res);
+    end
+    if verbose && exist('output', 'var')
+        fprintf(2, ['result saved to: ' output '\n']);
+    end
 end
 
 % vim: ft=octave


### PR DESCRIPTION
This uses the load() and save('-acii',...) functions from octave.

Additionally, the behavior is slightly changed regarding the decision to print to screen or save to file: before, if the output was a scalar, is was printed to stdout. To allow for saving scalar results in text files, this is now restricted to the cases where output=='-', that is, when the option '-o' is not specified. (or when `-o -` is specified -- this means that we can't pass scalar through pipes, but this was the same before this commit.)

Also cleaned the prog variable to remove trailing whitespaces and semicolons.